### PR TITLE
These changes better handle escaped characters in the format string.

### DIFF
--- a/js/php-date-formatter.js
+++ b/js/php-date-formatter.js
@@ -545,7 +545,8 @@ var DateFormatter;
                     return vDate.getTime() / 1000 || 0;
                 }
             };
-            return doFormat(vChar, vChar);
+            //return doFormat(vChar, vChar);
+            return vChar.replace(backspace, doFormat);
         },
         formatDate: function (vDate, vFormat) {
             var self = this, i, n, len, str, vChar, vDateStr = '';
@@ -556,6 +557,8 @@ var DateFormatter;
                 }
             }
             if (vDate instanceof Date) {
+	            return self.parseFormat(vFormat,vDate);
+	            /*
                 len = vFormat.length;
                 for (i = 0; i < len; i++) {
                     vChar = vFormat.charAt(i);
@@ -570,6 +573,7 @@ var DateFormatter;
                     vDateStr += str;
                 }
                 return vDateStr;
+                */
             }
             return '';
         }


### PR DESCRIPTION
Fix an issue where escaped characters in the format string were getting decoded instead of getting passed through.
e.g. “Y-m-d\Ti:m:s"
was resulting in: 2016-02-08\PST32:02:15
rather than the expected:2016-02-08T32:02:15
