### PR TITLE
Remove usage of reserved word as function attribute

### DIFF
--- a/js/php-date-formatter.js
+++ b/js/php-date-formatter.js
@@ -19,8 +19,9 @@ var DateFormatter;
     _compare = function (str1, str2) {
         return typeof(str1) === 'string' && typeof(str2) === 'string' && str1.toLowerCase() === str2.toLowerCase();
     };
-    _lpad = function (value, length, char) {
-        var chr = char || '0', val = value.toString();
+    _lpad = function (value, length, chr) {
+        var val = value.toString();
+        chr = chr || '0';
         return val.length < length ? _lpad(chr + val, length) : val;
     };
     _extend = function (out) {


### PR DESCRIPTION
Usage of "char" as attribute for _lpad function makes it impossible to compress JS with Closure Compiler without implicitly setting --language_in=ECMASCRIPT5
It also affects all libraries that use php-date-formatter, i.e. https://github.com/xdan/datetimepicker
